### PR TITLE
Bump `futures-util` version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,15 +470,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
@@ -507,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -518,15 +518,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-timer"
@@ -536,9 +536,9 @@ checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
  "futures-io",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ bytes = "1.6.0"
 cfg-if = "1.0.0"
 clap = { version = "4.5.4", default-features = false, features = ["derive", "error-context", "help", "std", "suggestions", "usage", "wrap_help"] }
 crossterm = "0.28.1"
-futures-util = { version = "0.3.30", default-features = false, features = ["sink"] }
+futures-util = { version = "0.3.31", default-features = false, features = ["sink"] }
 itertools = "0.13.0"
 pin-project-lite = "0.2.14"
 rustls-native-certs = { version = "0.8.0", optional = true }

--- a/THIRDPARTY.toml
+++ b/THIRDPARTY.toml
@@ -4303,7 +4303,7 @@ limitations under the License.
 
 [[third_party_libraries]]
 package_name = "futures-core"
-package_version = "0.3.30"
+package_version = "0.3.31"
 repository = "https://github.com/rust-lang/futures-rs"
 license = "MIT OR Apache-2.0"
 
@@ -4547,7 +4547,7 @@ limitations under the License.
 
 [[third_party_libraries]]
 package_name = "futures-io"
-package_version = "0.3.30"
+package_version = "0.3.31"
 repository = "https://github.com/rust-lang/futures-rs"
 license = "MIT OR Apache-2.0"
 
@@ -4791,7 +4791,7 @@ limitations under the License.
 
 [[third_party_libraries]]
 package_name = "futures-macro"
-package_version = "0.3.30"
+package_version = "0.3.31"
 repository = "https://github.com/rust-lang/futures-rs"
 license = "MIT OR Apache-2.0"
 
@@ -5035,7 +5035,7 @@ limitations under the License.
 
 [[third_party_libraries]]
 package_name = "futures-sink"
-package_version = "0.3.30"
+package_version = "0.3.31"
 repository = "https://github.com/rust-lang/futures-rs"
 license = "MIT OR Apache-2.0"
 
@@ -5279,7 +5279,7 @@ limitations under the License.
 
 [[third_party_libraries]]
 package_name = "futures-task"
-package_version = "0.3.30"
+package_version = "0.3.31"
 repository = "https://github.com/rust-lang/futures-rs"
 license = "MIT OR Apache-2.0"
 
@@ -5523,7 +5523,7 @@ limitations under the License.
 
 [[third_party_libraries]]
 package_name = "futures-util"
-package_version = "0.3.30"
+package_version = "0.3.31"
 repository = "https://github.com/rust-lang/futures-rs"
 license = "MIT OR Apache-2.0"
 


### PR DESCRIPTION
Because 0.3.30 was yanked.