### PR TITLE
Call `SinkExt::close()` on connection before dropping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
-v0.4.0 (in development)
+v0.3.2 (in development)
 -----------------------
 - Remove unintended "openssl" feature
 - Increased MSRV to 1.80
 - Linux release artifacts are now built on Ubuntu 22.04 (up from Ubuntu 20.04),
   which may result in a more recent glibc being required
+- The sending halves of TCP connections are now explicitly shut down when
+  disconnecting
 
 v0.3.1 (2023-12-13)
 -------------------

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "confab"
-version = "0.4.0-dev"
+version = "0.3.2-dev"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "confab"
-version = "0.4.0-dev"
+version = "0.3.2-dev"
 edition = "2021"
 rust-version = "1.80"
 description = "Asynchronous line-oriented interactive TCP client"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -33,4 +33,6 @@ pub(crate) enum InetError {
     Send(#[source] io::Error),
     #[error("failed to receive line from server")]
     Recv(#[source] io::Error),
+    #[error("erroring closing connection")]
+    Close(#[source] io::Error),
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -44,6 +44,9 @@ impl Runner {
         if let Some(script) = self.startup_script.take() {
             let cs = ioloop(&mut frame, script, &mut self.reporter).await?;
             if cs == ConnectState::Closed {
+                SinkExt::<&str>::close(&mut frame)
+                    .await
+                    .map_err(InetError::Close)?;
                 self.reporter.report(Event::disconnect())?;
                 return Ok(());
             }
@@ -61,6 +64,9 @@ impl Runner {
                     .report(Event::disconnect())
                     .map_err(IoError::from)
             });
+        SinkExt::<&str>::close(&mut frame)
+            .await
+            .map_err(InetError::Close)?;
         let _ = rl.flush();
         // Set the writer back to stdout so that errors reported by run() will
         // show up without having to call rl.flush().


### PR DESCRIPTION
Closes #305.

To Do:

- [x] If `close()` errors, ensure that the reporter's writer is set back to stdout before reporting
- [x] `close()` should probably be called even if an error occurred in `ioloop()`, but if it errors as well, how should things be reported?
    - Suppress/discard the report of the `close()` error?
- [x] Update CHANGELOG
- [x] Test against an actual server